### PR TITLE
Response fields live and api will only contain 1 item in the list

### DIFF
--- a/src/weerlive/models.py
+++ b/src/weerlive/models.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
+from typing import Any
 
 from mashumaro import field_options
 from mashumaro.mixins.orjson import DataClassORJSONMixin
@@ -16,10 +17,25 @@ from .helpers import str_to_datetime, time_to_datetime
 class Response(DataClassORJSONMixin):
     """Weerlive API response."""
 
-    live: list[LiveWeather] = field(metadata=field_options(alias="liveweer"))
+    live: LiveWeather = field(metadata=field_options(alias="liveweer"))
     daily_forecast: list[DailyForecast] = field(metadata=field_options(alias="wk_verw"))
     hourly_forecast: list[HourlyForecast] = field(metadata=field_options(alias="uur_verw"))
-    api: list[ApiInfo]
+    api: ApiInfo
+
+    @classmethod
+    def __pre_deserialize__(cls, d: dict[Any, Any]) -> dict[Any, Any]:
+        """Extract single items from lists for live and api fields."""
+        result = d.copy()
+
+        # Extract first item from liveweer list
+        if "liveweer" in result and isinstance(result["liveweer"], list) and result["liveweer"]:
+            result["liveweer"] = result["liveweer"][0]
+
+        # Extract first item from api list
+        if "api" in result and isinstance(result["api"], list) and result["api"]:
+            result["api"] = result["api"][0]
+
+        return result
 
 
 @dataclass

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -40,9 +40,9 @@ async def test_weerlive_initialization_with_session(mock_session: ClientSession)
 async def test_deserialization_amsterdam(weerlive_api: WeerliveApi) -> None:
     """Test deserialization of Amsterdam weather data."""
     response = await weerlive_api.city("Test")
-    assert response.live[0].city == "Amsterdam"
-    assert response.live[0].temperature == 19.1
-    assert response.live[0].summary == "Zwaar bewolkt"
+    assert response.live.city == "Amsterdam"
+    assert response.live.temperature == 19.1
+    assert response.live.summary == "Zwaar bewolkt"
 
     assert response.daily_forecast[0].max_temperature == 20
     assert response.daily_forecast[0].min_temperature == 15
@@ -50,8 +50,8 @@ async def test_deserialization_amsterdam(weerlive_api: WeerliveApi) -> None:
     assert response.hourly_forecast[0].temperature == 20
     assert response.hourly_forecast[0].solar_irradiance == 704
 
-    assert response.api[0].max_requests == 300
-    assert response.api[0].remaining_requests == 0
+    assert response.api.max_requests == 300
+    assert response.api.remaining_requests == 0
 
 
 @pytest.mark.usefixtures("json_response")
@@ -59,9 +59,9 @@ async def test_deserialization_amsterdam(weerlive_api: WeerliveApi) -> None:
 async def test_deserialization_groningen(weerlive_api: WeerliveApi) -> None:
     """Test deserialization of Groningen weather data."""
     response = await weerlive_api.latitude_longitude(latitude=53.21917, longitude=6.56667)
-    assert response.live[0].city == "Groningen"
-    assert response.live[0].temperature == 18.5
-    assert response.live[0].summary == "Zwaar bewolkt"
+    assert response.live.city == "Groningen"
+    assert response.live.temperature == 18.5
+    assert response.live.summary == "Zwaar bewolkt"
 
     assert response.daily_forecast[0].max_temperature == 18
     assert response.daily_forecast[0].min_temperature == 14
@@ -69,8 +69,8 @@ async def test_deserialization_groningen(weerlive_api: WeerliveApi) -> None:
     assert response.hourly_forecast[0].temperature == 18
     assert response.hourly_forecast[0].solar_irradiance == 404
 
-    assert response.api[0].max_requests == 300
-    assert response.api[0].remaining_requests == 299
+    assert response.api.max_requests == 300
+    assert response.api.remaining_requests == 299
 
 
 @pytest.mark.usefixtures("json_response")
@@ -78,9 +78,9 @@ async def test_deserialization_groningen(weerlive_api: WeerliveApi) -> None:
 async def test_deserialization_alarm(weerlive_api: WeerliveApi) -> None:
     """Test deserialization of alarm data."""
     response = await weerlive_api.city("Test")
-    assert response.live[0].next_alert_date == datetime.datetime(2024, 2, 22, 18, 0, tzinfo=ZoneInfo(API_TIMEZONE))
-    assert response.live[0].next_alert_timestamp == 1708621200
-    assert response.live[0].next_alert_weather_code == "geel"
+    assert response.live.next_alert_date == datetime.datetime(2024, 2, 22, 18, 0, tzinfo=ZoneInfo(API_TIMEZONE))
+    assert response.live.next_alert_timestamp == 1708621200
+    assert response.live.next_alert_weather_code == "geel"
 
 
 @pytest.mark.usefixtures("json_response")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to the project!
  Please, DO NOT DELETE ANY TEXT from this template!
-->

## Proposed change

<!--
  Please include a summary of the changes and link to any related issues.
  Please also include relevant motivation and context.
  Add one of the following labels to the PR:
    - bugfix
    - ci
    - dependencies
    - dev-environment
    - documentation
    - enhancement
    - new-feature
-->
Response fields live and api will only contain 1 item in the list.
We now deserialize these fields to a single item

## Breaking change

<!--
  Does this PR introduce any breaking changes?
  What changes might users need to make in their application due to this PR?
  Add the breaking-change label to the PR.
-->
`response.live` and `response.api` are no longer a list

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
